### PR TITLE
nokogiri を 1.10.4 へ更新する

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     wataridori (0.1.0)
       esa (~> 1.13.1)
       hashie (~> 3.6.0)
-      nokogiri (~> 1.8.5)
+      nokogiri (~> 1.10.4)
       retriable (~> 3.1.1)
 
 GEM
@@ -21,17 +21,17 @@ GEM
       multi_xml (~> 0.5.5)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.12.2)
+    faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     hashie (3.6.0)
     jaro_winkler (1.5.1)
     method_source (0.9.2)
     mime-types (2.99.3)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     multi_xml (0.5.5)
-    multipart-post (2.0.0)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    multipart-post (2.1.1)
+    nokogiri (1.10.4)
+      mini_portile2 (~> 2.4.0)
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)
@@ -81,4 +81,4 @@ DEPENDENCIES
   wataridori!
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/wataridori.gemspec
+++ b/wataridori.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_dependency 'esa', '~> 1.13.1'
   spec.add_dependency 'hashie', '~> 3.6.0'
-  spec.add_dependency 'nokogiri', '~> 1.8.5'
+  spec.add_dependency 'nokogiri', '~> 1.10.4'
   spec.add_dependency 'retriable', '~> 3.1.1'
 end


### PR DESCRIPTION
https://github.com/misoca/wataridori/network/alerts を解決するためです。